### PR TITLE
10 verify hmac signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,27 @@ Please make sure to [add the above payment methods to your Adyen account](https:
 ## Usage
 
 1. Run `./setup.sh` to install dependencies and to activate your `venv` if you haven't done already in above steps
-2. Update the config file `config.ini` with your [API key](https://docs.adyen.com/user-management/how-to-get-the-api-key), [Client Key](https://docs.adyen.com/user-management/client-side-authentication) - Remember to add `http://localhost:8080` as an origin for client key, and merchant account name like below:
+
+2. Update the config file `config.ini` with all required configuration 
+
+   - [API key](https://docs.adyen.com/user-management/how-to-get-the-api-key)
+   - [Client Key](https://docs.adyen.com/user-management/client-side-authentication) 
+   - [Merchant Account](https://docs.adyen.com/account/account-structure)
+   - [HMAC Key](https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures)
+
+Remember to include `http://localhost:8080` in the list of Allowed Origins
+
    ```
-   merchant_account = TestMerchantAccount
-   checkout_apikey = SampleAPIKey
-   client_key = SampleClientKey
+   merchant_account = "your_merchant_account_here"
+   apikey = "your_API_key_here"
+   client_key = "your_client_key_here"
+   hmac_key = "your_client_HMAC_key_here"
    ```
-3. Run `./start.sh` to:
+
+5. Run `./start.sh` to:
    - Initialize the required environment variables. This step is necessary every time you re-activate your (venv)
    - Run flask
-4. Visit [http://localhost:8080](http://localhost:8080) and select an integration type!
+6. Visit [http://localhost:8080](http://localhost:8080) and select an integration type!
 
 ## Contributing
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 
+from Adyen.util import is_valid_hmac_notification
 from flask import Flask, render_template, send_from_directory, request, abort
 
 from .main.config import read_config
@@ -72,8 +73,11 @@ def create_app():
         notifications = request.json['notificationItems']
 
         for notification in notifications:
-            print(f"merchantReference: {notification['NotificationRequestItem']['merchantReference']} "
-                  f"result? {notification['NotificationRequestItem']['success']}")
+            if is_valid_hmac_notification(notification['NotificationRequestItem'], config.hmac_key) :
+                print(f"merchantReference: {notification['NotificationRequestItem']['merchantReference']} "
+                      f"result? {notification['NotificationRequestItem']['success']}")
+            else:
+                raise Exception("Invalid HMAC signature")
 
         return '[accepted]'
 

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -9,12 +9,13 @@ Make sure to fill out your config.ini file!!!
 merchant_account = ""
 checkout_apikey = ""
 client_key = ""
+hmac_key = ""
 supported_integrations = ['dropin', 'card', 'ideal', 'klarna', 'directEbanking', 'alipay', 'boletobancario',
                           'sepadirectdebit', 'dotpay', 'giropay', 'ach', 'paypal', 'applepay']
 
 
 def read_config():
-    global merchant_account, checkout_apikey, client_key
+    global merchant_account, checkout_apikey, client_key, hmac_key
 
     config = configparser.ConfigParser(interpolation=None)
     config.read('config.ini')
@@ -22,6 +23,7 @@ def read_config():
     merchant_account = config['DEFAULT']['merchant_account']
     checkout_apikey = config['DEFAULT']['apikey']
     client_key = config['DEFAULT']['client_key']
+    hmac_key = config['DEFAULT']['hmac_key']
 
     # Check to make sure variables are set
     if not merchant_account or not checkout_apikey or not client_key:


### PR DESCRIPTION
Adding the validation of the HMAC signature included in the Webhook payload

**Note**: when HMAC signature is invalid the `acknowledge` is not sent (as per Adyen docs), which is different in other apps and might have to be revised.