### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -79,7 +79,7 @@ def create_app():
             # invalid hmac: do not send [accepted] response
             raise Exception("Invalid HMAC signature")
 
-        return '[accepted]'
+        return '', 202
 
     @app.route('/favicon.ico')
     def favicon():


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code 202 and an empty response body.

This PR updates all webhook handlers to implement the new approach.