### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Demo leverages Adyen's API Library for Python [GitHub](https://github.com/Ad
 - Python libraries:
   - flask
   - uuid
-  - Adyen v8.0.0 or higher
+  - Adyen v12.0.0 or higher
 
 ## Installation
 

--- a/app/templates/component.html
+++ b/app/templates/component.html
@@ -8,9 +8,9 @@
 
 	<!-- Adyen css from TEST environment (change to live for production)-->
 	<link rel="stylesheet"
-		 href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.css"
-		 integrity="sha384-BRZCzbS8n6hZVj8BESE6thGk0zSkUZfUWxL/vhocKu12k3NZ7xpNsIK39O2aWuni"
-		 crossorigin="anonymous">
+     	href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+     	integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+     	crossorigin="anonymous">
 
 	<div id="payment-page">
 		<div class="container">
@@ -25,9 +25,9 @@
 	</div>
 
 	<!-- Adyen JS from TEST environment (change to live for production)-->
-	<script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.js"
-		 integrity="sha384-ds1t0hgFCe636DXFRL6ciadL2Wb4Yihh27R4JO7d9CF7sFY3NJE4aPCK0EpzaYXD"
-		 crossorigin="anonymous"></script>
+	<script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+     	integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
+     	crossorigin="anonymous"></script>
 
 	<script id="client-key" type="application/json">{{ client_key|tojson }}</script>
 	<script id="integration-type" type="application/json">{{ method|tojson }}</script>


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area